### PR TITLE
Add InMemoryRoleManager. Change the way to switch RoleManager.

### DIFF
--- a/Annotation/SecureConfig.php
+++ b/Annotation/SecureConfig.php
@@ -24,6 +24,11 @@ class SecureConfig extends Annotation
     /**
      * @var string
      */
+    protected $roleManager;
+
+    /**
+     * @var string
+     */
     protected $forward;
 
     /**
@@ -50,6 +55,14 @@ class SecureConfig extends Annotation
     public function auth()
     {
         return $this->auth;
+    }
+
+    /**
+     * @return string
+     */
+    public function roleManager()
+    {
+        return $this->roleManager;
     }
 
     /**

--- a/CrocosSecurityBundle.php
+++ b/CrocosSecurityBundle.php
@@ -22,5 +22,6 @@ class CrocosSecurityBundle extends Bundle
         $container->addCompilerPass(new Compiler\TwigGlobalPass());
 
         $container->addCompilerPass(new Compiler\AuthLogicPass());
+        $container->addCompilerPass(new Compiler\RoleManagerPass());
     }
 }

--- a/DependencyInjection/Compiler/RoleManagerPass.php
+++ b/DependencyInjection/Compiler/RoleManagerPass.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Crocos\SecurityBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+
+/**
+ * RoleManagerPass.
+ *
+ * @author Toshiyuki Fujita <tofujiit@crocos.co.jp>
+ */
+class RoleManagerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        $definition = $container->getDefinition('crocos_security.role_manager_resolver');
+
+        // tags:
+        //   - { name: crocos_security.role_manager, alias: myrolemanager }
+        foreach ($container->findTaggedServiceIds('crocos_security.role_manager') as $id => $attributes) {
+            $definition->addMethodCall('registerRoleManager', array($attributes[0]['alias'], new Reference($id)));
+        }
+    }
+}

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -2,7 +2,6 @@ services:
     crocos_security.context:
         class: Crocos\SecurityBundle\Security\SecurityContext
         calls:
-            - [ setRoleManager, [ @crocos_security.role_manager ] ]
             - [ setPreviousUrlHolder, [ @crocos_security.previous_url_holder ] ]
 
     crocos_security.checker:
@@ -16,6 +15,7 @@ services:
         arguments:
             - @annotation_reader
             - @crocos_security.auth_logic_resolver
+            - @crocos_security.role_manager_resolver
             - @crocos_security.http_auth_factory
 
     crocos_security.forwarding_controller_matcher:
@@ -41,10 +41,17 @@ services:
     crocos_security.http_auth_factory:
         class: Crocos\SecurityBundle\Security\HttpAuth\HttpAuthFactory
 
-    crocos_security.role_manager:
-        alias: crocos_security.role_manager.session
+    crocos_security.role_manager_resolver:
+        class: Crocos\SecurityBundle\Security\Role\RoleManagerResolver
 
     crocos_security.role_manager.session:
         class: Crocos\SecurityBundle\Security\Role\SessionRoleManager
         arguments:
             - @session
+        tags:
+            - { name: crocos_security.role_manager, alias: session }
+
+    crocos_security.role_manager.in_memory:
+        class: Crocos\SecurityBundle\Security\Role\InMemoryRoleManager
+        tags:
+            - { name: crocos_security.role_manager, alias: in_memory }

--- a/Security/AnnotationLoader.php
+++ b/Security/AnnotationLoader.php
@@ -7,6 +7,7 @@ use Crocos\SecurityBundle\Annotation\Annotation;
 use Crocos\SecurityBundle\Annotation\Secure;
 use Crocos\SecurityBundle\Annotation\SecureConfig;
 use Crocos\SecurityBundle\Security\AuthLogic\AuthLogicResolver;
+use Crocos\SecurityBundle\Security\Role\RoleManagerResolver;
 use Crocos\SecurityBundle\Security\HttpAuth\HttpAuthFactoryInterface;
 use Crocos\SecurityBundle\Security\SecureOptionsAcceptableInterface;
 
@@ -18,6 +19,7 @@ use Crocos\SecurityBundle\Security\SecureOptionsAcceptableInterface;
 class AnnotationLoader
 {
     const DEFAULT_AUTH_LOGIC = 'session';
+    const DEFAULT_ROLE_MANAGER = 'session';
 
     /**
      * @var Reader
@@ -30,6 +32,11 @@ class AnnotationLoader
     protected $resolver;
 
     /**
+     * @var RoleManagerResolver
+     */
+    protected $roleManagerResolver;
+
+    /**
      * @var HttpAuthFactoryInterface
      */
     protected $httpAuthFactory;
@@ -39,11 +46,14 @@ class AnnotationLoader
      *
      * @param Reader $reader Annotation reader
      * @param AuthLogicResolver $resolver
+     * @param RoleManagerResolver $roleManagerResolver
+     * @param HttpAuthFactoryInterface $httpAuthFactory
      */
-    public function __construct(Reader $reader, AuthLogicResolver $resolver, HttpAuthFactoryInterface $httpAuthFactory = null)
+    public function __construct(Reader $reader, AuthLogicResolver $resolver, RoleManagerResolver $roleManagerResolver, HttpAuthFactoryInterface $httpAuthFactory = null)
     {
         $this->reader = $reader;
         $this->resolver = $resolver;
+        $this->roleManagerResolver = $roleManagerResolver;
         $this->httpAuthFactory = $httpAuthFactory;
     }
 
@@ -143,6 +153,10 @@ class AnnotationLoader
             $context->setAuthLogic($this->resolver->resolveAuthLogic($annotation->auth()));
         }
 
+        if (null !== $annotation->roleManager()) {
+            $context->setRoleManager($this->roleManagerResolver->resolveRoleManager($annotation->roleManager()));
+        }
+
         if (null !== $annotation->forward()) {
             $context->setForwardingController($annotation->forward());
         }
@@ -161,6 +175,10 @@ class AnnotationLoader
     {
         if (null === $context->getAuthLogic()) {
             $context->setAuthLogic($this->resolver->resolveAuthLogic(self::DEFAULT_AUTH_LOGIC));
+        }
+
+        if (null === $context->getRoleManager()) {
+            $context->setRoleManager($this->roleManagerResolver->resolveRoleManager(self::DEFAULT_ROLE_MANAGER));
         }
 
         if ($context->getAuthLogic() instanceof SecureOptionsAcceptableInterface) {

--- a/Security/Role/InMemoryRoleManager.php
+++ b/Security/Role/InMemoryRoleManager.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Crocos\SecurityBundle\Security\Role;
+
+/**
+ * InMemoryRoleManager.
+ *
+ * @author Toshiyuki Fujita <tofujiit@crocos.co.jp>
+ */
+class InMemoryRoleManager implements RoleManagerInterface
+{
+    protected $domain;
+    protected $attributes = array();
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->attributes = array();
+    }
+
+    /**
+     * @param string $domain
+     */
+    public function setDomain($domain)
+    {
+        $this->domain = $domain;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasRole($roles)
+    {
+        if (!is_array($roles)) {
+            $roles = array($roles);
+        }
+
+        if (count($roles) === 0) {
+            return true;
+        }
+
+        $grantedRoles = $this->getRoles();
+
+        if (count(array_intersect($roles, $grantedRoles)) === 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setRoles($roles)
+    {
+        $this->setAttribute('roles', (array)$roles);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addRoles($roles)
+    {
+        $roles = array_unique(array_merge($this->getRoles(), (array)$roles), SORT_STRING);
+        $this->setRoles($roles);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getRoles()
+    {
+        return $this->getAttribute('roles', array());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clearRoles()
+    {
+        $this->setAttribute('roles', array());
+        $this->setAttribute('preloaded', false);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isPreloaded()
+    {
+        return $this->getAttribute('preloaded', false);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setPreloaded($preloaded = true)
+    {
+        $this->setAttribute('preloaded', (bool)$preloaded);
+    }
+
+    /**
+     * Set attribute to memory.
+     *
+     * @param string $key
+     * @param mixed $value
+     */
+    protected function setAttribute($key, $value)
+    {
+        $this->attributes[$this->domain][$key] = $value;
+    }
+
+    /**
+     * Get attribute from memory.
+     *
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
+     */
+    protected function getAttribute($key, $default = null)
+    {
+        return isset($this->attributes[$this->domain][$key]) ?
+            $this->attributes[$this->domain][$key] : $default;
+    }
+}

--- a/Security/Role/RoleManagerResolver.php
+++ b/Security/Role/RoleManagerResolver.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Crocos\SecurityBundle\Security\Role;
+
+/**
+ * RoleManagerResolver.
+ *
+ * @author Toshiyuki Fujita <tofujiit@crocos.co.jp>
+ */
+class RoleManagerResolver
+{
+    /**
+     * @var array
+     */
+    protected $roleManagers = array();
+
+    /**
+     * Register role manager.
+     *
+     * @param string $name
+     * @param RoleManagerInterface $roleManager
+     */
+    public function registerRoleManager($name, RoleManagerInterface $roleManager)
+    {
+        $this->roleManagers[$name] = $roleManager;
+    }
+
+    /**
+     * Resolve role manager by name.
+     *
+     * @param string $name
+     * @return RoleManagerInterface
+     *
+     * @throws \InvalidArgumentException If no role manager matched given name
+     */
+    public function resolveRoleManager($name)
+    {
+        if (!isset($this->roleManagers[$name])) {
+            throw new \InvalidArgumentException(sprintf('No role manager registered "%s"', $name));
+        }
+
+        return $this->roleManagers[$name];
+    }
+}

--- a/Tests/Annotation/SecureConfigTest.php
+++ b/Tests/Annotation/SecureConfigTest.php
@@ -10,14 +10,16 @@ class SecureConfigTest extends \PHPUnit_Framework_TestCase
     public function testLoad()
     {
         $secure = new SecureConfig(array(
-            'domain'  => 'secured',
-            'auth'    => 'session',
-            'forward' => 'AdminController::loginAction',
-            'basic'   => 'foo:foopass',
+            'domain'      => 'secured',
+            'auth'        => 'session',
+            'roleManager' => 'session',
+            'forward'     => 'AdminController::loginAction',
+            'basic'       => 'foo:foopass',
         ));
 
         $this->assertEquals('secured', $secure->domain());
         $this->assertEquals('session', $secure->auth());
+        $this->assertEquals('session', $secure->roleManager());
         $this->assertEquals('AdminController::loginAction', $secure->forward());
         $this->assertEquals('foo:foopass', $secure->basic());
     }

--- a/Tests/Fixtures/AdminController.php
+++ b/Tests/Fixtures/AdminController.php
@@ -3,7 +3,11 @@
 namespace Crocos\SecurityBundle\Tests\Fixtures;
 
 use Crocos\SecurityBundle\Annotation\Secure;
+use Crocos\SecurityBundle\Annotation\SecureConfig;
 
+/**
+ * @SecureConfig(roleManager="in_memory")
+ */
 class AdminController extends SecureController
 {
     public function securedAction()

--- a/Tests/Security/AnnotationLoaderTest.php
+++ b/Tests/Security/AnnotationLoaderTest.php
@@ -14,12 +14,9 @@ class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getLoadAnnotationData
      */
-    public function testLoadAnnotation($object, $method, $secure, $allow, $domain, $options, $auth, $forward, $basic = null)
+    public function testLoadAnnotation($object, $method, $secure, $allow, $domain, $options, $auth, $roleMng, $forward, $basic = null)
     {
         $context = Phake::partialMock('Crocos\SecurityBundle\Security\SecurityContext');
-
-        $roleManager = Phake::mock('Crocos\SecurityBundle\Security\Role\RoleManagerInterface');
-        $context->setRoleManager($roleManager);
 
         $previousUrlHolder = Phake::mock('Crocos\SecurityBundle\Security\PreviousUrlHolder');
         $context->setPreviousUrlHolder($previousUrlHolder);
@@ -31,16 +28,20 @@ class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
         $reflObject = new \ReflectionObject($object);
 
         $resolver = Phake::mock('Crocos\SecurityBundle\Security\AuthLogic\AuthLogicResolver');
+        $roleManagerResolver = Phake::mock('Crocos\SecurityBundle\Security\Role\RoleManagerResolver');
         $authLogic = Phake::mock('Crocos\SecurityBundle\Tests\Fixtures\ComplexedAuthLogicInterface');
+        $roleManager = Phake::mock('Crocos\SecurityBundle\Security\Role\RoleManagerInterface');
         Phake::when($resolver)->resolveAuthLogic($auth ?: AnnotationLoader::DEFAULT_AUTH_LOGIC)->thenReturn($authLogic);
+        Phake::when($roleManagerResolver)->resolveRoleManager($roleMng ?: AnnotationLoader::DEFAULT_ROLE_MANAGER)->thenReturn($roleManager);
 
-        $loader = new AnnotationLoader(new AnnotationReader(), $resolver, $httpAuthFacory);
+        $loader = new AnnotationLoader(new AnnotationReader(), $resolver, $roleManagerResolver, $httpAuthFacory);
         $loader->load($context, $reflObject, $reflObject->getMethod($method));
 
         $this->assertEquals($secure, $context->isSecure());
         $this->assertEquals($allow, $context->getAllowedRoles());
         $this->assertEquals($forward, $context->getForwardingController());
         $this->assertEquals($authLogic, $context->getAuthLogic());
+        $this->assertEquals($roleManager, $context->getRoleManager());
         $this->assertEquals($options, $context->getOptions());
 
         if ($basic) {
@@ -60,19 +61,19 @@ class AnnotationLoaderTest extends \PHPUnit_Framework_TestCase
         $fforward = 'Crocos\SecurityBundle\Tests\Fixtures\FacebookController::loginAction';
 
         return array(
-            // object, method, secure, allow, domain, options, auth, forward [, basic]
+            // object, method, secure, allow, domain, options, auth, roleManager, forward [, basic]
 
-            array(new Fixtures\UserController(), 'securedAction', true, array(), 'secured', array(), 'session', $uforward),
-            array(new Fixtures\UserController(), 'publicAction', false, array(), 'secured', array(), 'session', $uforward),
-            array(new Fixtures\UserController(), 'loginAction',  false, array(), 'secured', array(), 'session', $uforward),
+            array(new Fixtures\UserController(), 'securedAction', true, array(), 'secured', array(), 'session', 'session', $uforward),
+            array(new Fixtures\UserController(), 'publicAction', false, array(), 'secured', array(), 'session', 'session', $uforward),
+            array(new Fixtures\UserController(), 'loginAction',  false, array(), 'secured', array(), 'session', 'session', $uforward),
 
-            array(new Fixtures\AdminController(), 'securedAction', true, array(), 'admin', array(), 'session', $aforward),
-            array(new Fixtures\AdminController(), 'publicAction', false, array(), 'admin', array(), 'session', $aforward),
-            array(new Fixtures\AdminController(), 'adminAction',   true, array('admin'), 'admin', array(), 'session', $aforward),
+            array(new Fixtures\AdminController(), 'securedAction', true, array(), 'admin', array(), 'session', 'in_memory', $aforward),
+            array(new Fixtures\AdminController(), 'publicAction', false, array(), 'admin', array(), 'session', 'in_memory', $aforward),
+            array(new Fixtures\AdminController(), 'adminAction',   true, array('admin'), 'admin', array(), 'session', 'in_memory', $aforward),
 
-            array(new Fixtures\FacebookController(), 'securedAction', true, array(), 'facebook', array('group' => array('10000001' => 'ADMIN')), 'facebook', $fforward),
+            array(new Fixtures\FacebookController(), 'securedAction', true, array(), 'facebook', array('group' => array('10000001' => 'ADMIN')), 'facebook', 'session', $fforward),
 
-            array(new Fixtures\BasicSecurityController(), 'securedAction', false, array(), 'secured', array(), null, null, 'foo:foopass')
+            array(new Fixtures\BasicSecurityController(), 'securedAction', false, array(), 'secured', array(), null, null, null, 'foo:foopass')
         );
     }
 }

--- a/Tests/Security/Role/InMemoryRoleManagerTest.php
+++ b/Tests/Security/Role/InMemoryRoleManagerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Crocos\SecurityBundle\Tests\Security\Role;
+
+use Crocos\SecurityBundle\Security\Role\InMemoryRoleManager;
+use Phake;
+
+class InMemoryRoleManagerTest extends \PHPUnit_Framework_TestCase
+{
+    protected $roleManager;
+
+    protected function setUp()
+    {
+        $session = Phake::mock('Symfony\Component\HttpFoundation\Session');
+        $roleManager = new InMemoryRoleManager();
+        $roleManager->setDomain('secured');
+
+        $this->roleManager = $roleManager;
+    }
+
+    public function testHasRoleReturnsTrueIfEmptyRolesIsPasssed()
+    {
+        $this->assertTrue($this->roleManager->hasRole(array()));
+    }
+
+    public function testHasRoleReturnsTrueIfAPassedRoleIsGranted()
+    {
+        $this->roleManager->setRoles(array('FOO', 'BAR'));
+
+        $this->assertTrue($this->roleManager->hasRole('FOO'));
+    }
+
+    public function testHasRoleReturnsTrueIfPassedRolesContainAnyGrantedRole()
+    {
+        $this->roleManager->setRoles(array('FOO', 'BAR'));
+
+        $this->assertTrue($this->roleManager->hasRole(array('BAR', 'BAZ')));
+    }
+
+    public function testHasRoleReturnsFalseIfPassedRolesDoesNotContaineGrantedRole()
+    {
+        $this->roleManager->setRoles(array('FOO', 'BAR'));
+
+        $this->assertFalse($this->roleManager->hasRole('XYZ'));
+    }
+
+    public function testSetAndGetRoles()
+    {
+        $this->roleManager->setRoles(array('FOO', 'BAR'));
+
+        $this->assertSame(array('FOO', 'BAR'), $this->roleManager->getRoles());
+    }
+
+    public function testAddRoles()
+    {
+        $this->roleManager->setRoles(array('FOO', 'BAR'));
+        $this->roleManager->addRoles('BAZ');
+
+        $this->assertSame(array('FOO', 'BAR', 'BAZ'), $this->roleManager->getRoles());
+    }
+
+    public function testClearRoles()
+    {
+        $this->roleManager->setRoles(array('FOO', 'BAR'));
+        $this->roleManager->clearRoles();
+
+        $this->assertSame(array(), $this->roleManager->getRoles());
+    }
+
+    public function testPreload()
+    {
+        $this->assertFalse($this->roleManager->isPreloaded());
+
+        $this->roleManager->setPreloaded();
+
+        $this->assertTrue($this->roleManager->isPreloaded());
+    }
+}

--- a/Tests/Security/Role/RoleManagerResolverTest.php
+++ b/Tests/Security/Role/RoleManagerResolverTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Crocos\SecurityBundle\Tests\Security\Role;
+
+use Crocos\SecurityBundle\Security\Role\RoleManagerResolver;
+use Phake;
+
+class RoleManagerResolverTest extends \PHPUnit_Framework_TestCase
+{
+    protected $resolver;
+
+    protected function setUp()
+    {
+        $resolver = new RoleManagerResolver();
+
+        $this->resolver = $resolver;
+    }
+
+    public function testResolveRoleManager()
+    {
+        $roleManager = Phake::mock('Crocos\SecurityBundle\Security\Role\RoleManagerInterface');
+        $this->resolver->registerRoleManager('foo', $roleManager);
+
+        $this->assertEquals($roleManager, $this->resolver->resolveRoleManager('foo'));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testResolveRoleManagerThrowInvalidArgumentExceptionIfNotRegistered()
+    {
+        $this->resolver->resolveRoleManager('wozozo');
+    }
+}


### PR DESCRIPTION
### 概要

リクエストごとにロールを変えたい場合など、
セッションベースではなくメモリベースでロールを管理したい場合もあるので、
`InMemoryRoleManager` を追加しました。

また、アノテーションで `RoleManager` を変更できるようにしました。
例) `@SecureConfig(roleManager="in_memory")`
### 注意点

アノテーションで変更出来るようにした関係で、
`AnnotationLoader#__construct` のメソッドシグネチャを変更したため、
後方互換性がなくなっています。
通常直接使用することはないので問題ないとは思いますが、ご確認のほどお願いします。
