### PR TITLE
Fix HTTP Status Code

### DIFF
--- a/EventListener/AuthListener.php
+++ b/EventListener/AuthListener.php
@@ -114,7 +114,7 @@ class AuthListener
         }
 
         if (null !== $response) {
-            $response->headers->set('X-Status-Code', 200);
+            $response->headers->set('X-Status-Code', $response->getStatusCode());
             $event->setResponse($response);
         }
     }

--- a/Tests/EventListener/AuthListenerTest.php
+++ b/Tests/EventListener/AuthListenerTest.php
@@ -106,7 +106,7 @@ class AuthListenerTest extends \PHPUnit_Framework_TestCase
 
         Phake::verify($httpAuth)->createUnauthorizedResponse($this->request, $exception);
         Phake::verify($event)->setResponse($response);
-        $this->assertEquals(200 , $response->headers->get('X-Status-Code'));
+        $this->assertEquals(401 , $response->headers->get('X-Status-Code'));
     }
 
     public function testHandleHttpsRequiredAuthException()
@@ -126,7 +126,7 @@ class AuthListenerTest extends \PHPUnit_Framework_TestCase
         Phake::verify($event)->setResponse(Phake::capture($redirectResponse));
 
         $this->assertStringStartsWith('https://', $redirectResponse->getTargetUrl());
-        $this->assertEquals(200 , $redirectResponse->headers->get('X-Status-Code'));
+        $this->assertEquals(302 , $redirectResponse->headers->get('X-Status-Code'));
     }
 
     protected function fixKernelEventMock($event)


### PR DESCRIPTION
## なぜこの変更をするか

非ログイン状態で認証が必要なコントローラにアクセスした場合に、SecureConfigのforwardに設定されたコントローラが呼び出されますが、この時のレスポンスヘッダーがHTTP Status Code 500で返っている問題があったため修正
## 原因

Symfony2.1から、`HttpKernel`の例外ハンドリングの仕方が変わったため。
`Response`のheadersに`X-Status-Code`が設定されていないと、HTTP Status-Code 500のレスポンスが返す仕様となった。

参考
http://symfony.com/doc/2.3/book/internals.html#kernel-exception-event
https://github.com/symfony/symfony/blob/2.3/src/Symfony/Component/HttpKernel/HttpKernel.php#L188
## 
## 影響範囲
- 特になし (bugfixであり、これまでステータスコード500であった部分が直る)
## テスト結果とテスト項目
- [x] 非ログイン状態で認証が必要なコントローラにアクセスし、ステータスコード200が返ること
- [x] https必須のエリアにhttpでアクセスした場合に、302 Foundとなっていること
- [x] basic認証のアクセスで401 Unauthorized
- [x] テストコードが通ること
## その他

特になし
