### PR TITLE
Support symfony >= 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,20 +13,20 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/framework-bundle": "2.3.*@dev",
-        "symfony/http-foundation": "2.3.*@dev",
-        "doctrine/common": "2.2.*"
+        "symfony/framework-bundle": ">=2.1.0@dev",
+        "symfony/http-foundation": ">=2.1.0@dev",
+        "doctrine/common": ">=2.2.0"
     },
     "require-dev": {
-        "symfony/config": "2.3.*@dev",
-        "symfony/dependency-injection": "2.3.*@dev",
-        "symfony/doctrine-bridge": "2.3.*@dev",
-        "symfony/event-dispatcher": "2.3.*@dev",
-        "symfony/http-kernel": "2.3.*@dev",
-        "doctrine/orm": ">=2.2.3,<2.4-dev",
+        "symfony/config": ">=2.1.0@dev",
+        "symfony/dependency-injection": ">=2.1.0@dev",
+        "symfony/doctrine-bridge": ">=2.1.0@dev",
+        "symfony/event-dispatcher": ">=2.1.0@dev",
+        "symfony/http-kernel": ">=2.1.0@dev",
+        "doctrine/orm": ">=2.2.3",
         "facebook/php-sdk": "dev-master",
-        "phpunit/phpunit": "3.7.*",
-        "phake/phake": "2.0.*@dev"
+        "phpunit/phpunit": ">=3.7.0",
+        "phake/phake": ">=2.0.0@dev"
     },
     "autoload": {
         "psr-0": { "Crocos\\SecurityBundle": "" }


### PR DESCRIPTION
## 概要
- symfony 関連の依存パッケージのバージョンが `2.3.*` になっていて、`2.6.*`で使えないので、変更した。
## テスト結果とテスト項目
- [x] php composer.phar validate が通ることを確認した
- [x] symfony2.6 の環境で、`@SecureConfig(forward="HogeBundle:Admin:moge", domain="admin", basic="admin:pass")` が動くことくらいは確認した
- [x] php composer.phar install --dev すると、symfonyの2.7-dev が入ることを確認した
## その他
- 最初 `^2.0.0@dev` を使って、`>=2.0.0@dev,<3.0@dev` を表現していたけど、テストで fail したので変更した。手元では正常に `composer install --dev` 終了したんだけどな。
- https://travis-ci.org/crocos/CrocosSecurityBundle/jobs/44808306 
### 参考

`~` とか `^` のドキュメント
- https://getcomposer.org/doc/01-basic-usage.md#package-versions
